### PR TITLE
Fix: Update __init__.py to reflect recent changes

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,20 +1,22 @@
 # __init__.py
 
-from .detail_daemon_node import DetailDaemonSamplerNode, DetailDaemonGraphSigmasNode, MultiplySigmas, LyingSigmaSamplerNode
+from .detail_daemon_node import DetailDaemonSamplerNode, DetailDaemonGraphSigmasNode, MultiplySigmas, LyingSigmaSamplerNode, DetailDaemonWan21SamplerNode
 
 NODE_CLASS_MAPPINGS = {
-    "DetailDaemonSamplerNode": DetailDaemonSamplerNode,
-    "DetailDaemonGraphSigmasNode": DetailDaemonGraphSigmasNode,
+    "DetailDaemonSampler": DetailDaemonSamplerNode,
+    "DetailDaemonGraphSigmas": DetailDaemonGraphSigmasNode,
     "MultiplySigmas": MultiplySigmas,
-    "LyingSigmaSampler": LyingSigmaSamplerNode
+    "LyingSigmaSampler": LyingSigmaSamplerNode,
+    "DetailDaemonWan21Sampler": DetailDaemonWan21SamplerNode,
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
-    "DetailDaemonSamplerNode": "Detail Daemon Sampler",
-    "DetailDaemonGraphSigmasNode": "Detail Daemon Graph Sigmas",
-    "MultiplySigmas": "Multiply Sigmas (stateless)",
+    "DetailDaemonSampler": "Detail Daemon Sampler",
+    "DetailDaemonGraphSigmas": "Detail Daemon Graph Sigmas",
+    "MultiplySigmas": "Multiply Sigmas",
     "LyingSigmaSampler": "Lying Sigma Sampler",
+    "DetailDaemonWan21Sampler": "Detail Daemon Sampler (wan 2.1)",
 }
 
-__all__ = ["NODE_CLASS_MAPPINGS"]
+__all__ = ["NODE_CLASS_MAPPINGS", "NODE_DISPLAY_NAME_MAPPINGS"]
 


### PR DESCRIPTION
The __init__.py file was not up-to-date with detail_daemon_node.py.

This commit synchronizes __init__.py by:
- Adding DetailDaemonWan21SamplerNode and its corresponding entries in NODE_CLASS_MAPPINGS and NODE_DISPLAY_NAME_MAPPINGS.
- Standardizing the key naming in NODE_CLASS_MAPPINGS and NODE_DISPLAY_NAME_MAPPINGS by removing the 'Node' suffix.
- Correcting the display name for 'MultiplySigmas' in NODE_DISPLAY_NAME_MAPPINGS.
- Ensuring both NODE_CLASS_MAPPINGS and NODE_DISPLAY_NAME_MAPPINGS are exported in __all__.