### PR TITLE
Fix: Increase sensitivity of Advanced Artifact Control

### DIFF
--- a/detail_daemon_node.py
+++ b/detail_daemon_node.py
@@ -89,8 +89,8 @@ def make_detail_daemon_schedule(
     # Limit the rate of change between successive multiplier values
     # This helps to smooth out abrupt jumps in the schedule.
     # Controlled by artifact_control: 0.0 = more smoothing (smaller max_delta), 1.0 = less smoothing (larger max_delta)
-    base_max_delta = 0.30
-    min_max_delta = 0.05
+    base_max_delta = 0.15
+    min_max_delta = 0.01
     # artifact_control = 1 -> dynamic_max_delta = base_max_delta
     # artifact_control = 0 -> dynamic_max_delta = min_max_delta
     dynamic_max_delta = min_max_delta + (base_max_delta - min_max_delta) * artifact_control


### PR DESCRIPTION
The Advanced Artifact Control feature was not producing a noticeable effect with default parameter settings. This was because the thresholds (`min_max_delta` and `base_max_delta`) used to determine when schedule smoothing should occur were too high relative to the typical deltas in the schedule generated with default `detail_amount`.

This commit adjusts these thresholds:
- `min_max_delta` changed from 0.05 to 0.01
- `base_max_delta` changed from 0.30 to 0.15

These changes ensure that the artifact control smoothing engages more readily, particularly when `artifact_control` is set for maximum effect (0.0), even with default `detail_amount` values. This should make the feature's impact more observable as per your expectations.